### PR TITLE
chore: support React Native's Metro bundler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6844,9 +6844,9 @@
 			"dev": true
 		},
 		"node_modules/sort-package-json": {
-			"version": "1.53.1",
-			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.53.1.tgz",
-			"integrity": "sha512-ltLORrQuuPMpy23YkWCA8fO7zBOxM4P1j9LcGxci4K2Fk8jmSyCA/ATU6CFyy8qR2HQRx4RBYWzoi78FU/Anuw==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.54.0.tgz",
+			"integrity": "sha512-MA0nRiSfZ4/CNM/9rz70Hwq4PpvtBc3v532tzQSmoaLSdeBB3cCd488xmNruLL0fb/ZdbKlcaDDudwnrObbjBw==",
 			"dev": true,
 			"dependencies": {
 				"detect-indent": "^6.0.0",
@@ -13043,9 +13043,9 @@
 			"dev": true
 		},
 		"sort-package-json": {
-			"version": "1.53.1",
-			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.53.1.tgz",
-			"integrity": "sha512-ltLORrQuuPMpy23YkWCA8fO7zBOxM4P1j9LcGxci4K2Fk8jmSyCA/ATU6CFyy8qR2HQRx4RBYWzoi78FU/Anuw==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.54.0.tgz",
+			"integrity": "sha512-MA0nRiSfZ4/CNM/9rz70Hwq4PpvtBc3v532tzQSmoaLSdeBB3cCd488xmNruLL0fb/ZdbKlcaDDudwnrObbjBw==",
 			"dev": true,
 			"requires": {
 				"detect-indent": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	},
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",
+	"react-native": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist",

--- a/siroc.config.ts
+++ b/siroc.config.ts
@@ -1,9 +1,28 @@
-import { defineSirocConfig } from "siroc";
+import { defineSirocConfig, PackageJson } from "siroc";
+import fs from "fs";
 
 export default defineSirocConfig({
 	rollup: {
 		output: {
 			sourcemap: true,
+		},
+	},
+	hooks: {
+		"build:done": (pkg) => {
+			// Type assertion is needed to add the `react-native`
+			// key. It is non-standard and not included in
+			// `siroc`'s built-in types.
+			const packageJson = pkg.pkg as PackageJson & {
+				["react-native"]?: string;
+			};
+
+			if (
+				packageJson.module &&
+				packageJson["react-native"] &&
+				pkg.pkg.module !== packageJson["react-native"]
+			) {
+				fs.copyFileSync(packageJson.module, packageJson["react-native"]);
+			}
 		},
 	},
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for use in React Native projects by adding an explicit `react-native` key to `package.json`. It points to the ES Module bundle.

### Background info

React Native's bundler (Metro) does not support `.cjs` files. Since Metro uses the `main` entry in `package.json`, it tries to load `dist/index.cjs` unsuccessfully.

Metro resolves package entry files using the following order:
- `react-native`
- `browser`
- `main`

Fixes: #2

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
⚛️
