### PR TITLE
fix: ignore `h` and `height` in `buildWidthSrcSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.6](https://github.com/prismicio-community/imgix-url-builder/compare/v0.0.5...v0.0.6) (2025-03-31)
+
+
+### Bug Fixes
+
+* ignore `h` and `height` in `buildWidthSrcSet` ([2f0970d](https://github.com/prismicio-community/imgix-url-builder/commit/2f0970df941b8f6e099d41ed649c54074d214f93))
+
 ### [0.0.5](https://github.com/prismicio-community/imgix-url-builder/compare/v0.0.4...v0.0.5) (2024-07-22)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "imgix-url-builder",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "imgix-url-builder",
-			"version": "0.0.5",
+			"version": "0.0.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@size-limit/preset-small-lib": "^11.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "imgix-url-builder",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"description": "JavaScript/TypeScript Imgix URL builders for browsers and Node.js",
 	"keywords": [
 		"typescript",

--- a/src/buildWidthSrcSet.ts
+++ b/src/buildWidthSrcSet.ts
@@ -4,7 +4,10 @@ import { buildURL } from "./buildURL";
 /**
  * Parameters for `buildWidthSrcSet`.
  */
-export type BuildWidthSrcSetParams = Omit<ImgixURLParams, "width" | "w"> & {
+export type BuildWidthSrcSetParams = Omit<
+	ImgixURLParams,
+	"width" | "w" | "height" | "h"
+> & {
 	/**
 	 * The pixel widths to include in the resulting `srcset` value.
 	 *
@@ -23,7 +26,8 @@ export type BuildWidthSrcSetParams = Omit<ImgixURLParams, "width" | "w"> & {
  *
  * The `width` URL parameter will be applied for each `srcset` entry. If a
  * `width` or `w` parameter is provided to the `params` parameter, it will be
- * ignored.
+ * ignored. Similarly, if a `height` or `h` parameter is provided to the
+ * `params` parameter, it will be ignored to prevent unexpected aspect ratio.
  *
  * @example
  *
@@ -61,7 +65,7 @@ export const buildWidthSrcSet = (
 ): string => {
 	return widths
 		.map((width) => {
-			return `${buildURL(url, { ...params, w: undefined, width })} ${width}w`;
+			return `${buildURL(url, { ...params, w: undefined, h: undefined, height: undefined, width })} ${width}w`;
 		})
 		.join(", ");
 };

--- a/test/buildWidthSrcSet.test.ts
+++ b/test/buildWidthSrcSet.test.ts
@@ -28,3 +28,21 @@ test("applies URL parameters if given", (t) => {
 
 	t.is(actual, expected);
 });
+
+test("ignores width and height related parameters", (t) => {
+	const source = "https://example.com/image.png";
+	const actual = buildWidthSrcSet(source, {
+		widths: [400, 800, 1600],
+		// @ts-expect-error - testing invalid params
+		width: 200,
+		w: 300,
+		height: 400,
+		h: 500,
+	});
+	const expected =
+		"https://example.com/image.png?width=400 400w, " +
+		"https://example.com/image.png?width=800 800w, " +
+		"https://example.com/image.png?width=1600 1600w";
+
+	t.is(actual, expected);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This pull request ignores the `h` and `height` parameters when building a width-based srcset to prevent images from using unexpected aspect ratios when rendered through `buildWidthSrcSet()`

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
